### PR TITLE
Allow OSM URL as relation ID input

### DIFF
--- a/web/static/js/menu.js
+++ b/web/static/js/menu.js
@@ -10,6 +10,7 @@ import { routeData } from './waysRoute.js'
 const busAnimationElement = document.getElementById('bus-animation')
 const loadRelationForm = document.getElementById('load-relation-form')
 const loadRelationBtn = loadRelationForm.querySelector('button[type=submit]')
+const relationIdInput = loadRelationForm.querySelector('input[name=relation-id]');
 const relationIdElements = document.querySelectorAll('.view .relation-id')
 const relationUrlElements = document.querySelectorAll('.view .relation-url')
 const editBackBtn = document.querySelector('#view-edit .btn-back')
@@ -37,30 +38,24 @@ const switchView = name => {
     activeView = name
 }
 
+relationIdInput.addEventListener('input', e => {
+    const osmOrgRelationRegex = /\d+/;
+    const reMatch = relationIdInput.value.match(osmOrgRelationRegex);
+    if (reMatch !== null) {
+        e.target.value = reMatch[0];
+        e.target.defaultValue = reMatch[0];
+    } else {
+        e.target.value = '';
+    }
+});
+
 loadRelationForm.addEventListener('submit', e => {
     e.preventDefault()
 
     if (loadRelationBtn.classList.contains('is-loading'))
         return
 
-    const relationIdInput = loadRelationForm.querySelector('input[name=relation-id]')
     relationId = parseInt(relationIdInput.value)
-    if (isNaN(relationId)) {
-        const osmOrgRelationRegex = /https:\/\/(?:www\.)?openstreetmap.org\/relation\/(\d+)/;
-        const reMatch = relationIdInput.value.match(osmOrgRelationRegex);
-        if (reMatch !== null) {
-            relationId = parseInt(reMatch[1]);
-        } else {
-            console.log("invalid relation");
-            showMessage(
-                'danger',
-                '❌ invalid relation ID or URL',
-                'The relation id or URL entered is invalid',
-            )
-            return;
-        }
-    }
-
     relationIdInput.disabled = true
     loadRelationBtn.classList.add('btn-secondary')
     loadRelationBtn.classList.add('is-loading')

--- a/web/static/js/menu.js
+++ b/web/static/js/menu.js
@@ -45,6 +45,21 @@ loadRelationForm.addEventListener('submit', e => {
 
     const relationIdInput = loadRelationForm.querySelector('input[name=relation-id]')
     relationId = parseInt(relationIdInput.value)
+    if (isNaN(relationId)) {
+        const osmOrgRelationRegex = /https:\/\/(?:www\.)?openstreetmap.org\/relation\/(\d+)/;
+        const reMatch = relationIdInput.value.match(osmOrgRelationRegex);
+        if (reMatch !== null) {
+            relationId = parseInt(reMatch[1]);
+        } else {
+            console.log("invalid relation");
+            showMessage(
+                'danger',
+                '❌ invalid relation ID or URL',
+                'The relation id or URL entered is invalid',
+            )
+            return;
+        }
+    }
 
     relationIdInput.disabled = true
     loadRelationBtn.classList.add('btn-secondary')

--- a/web/templates/_menu.jinja2
+++ b/web/templates/_menu.jinja2
@@ -4,7 +4,7 @@
 
     <div class="view" id="view-load">
         <h5 class="title">
-            Enter a <b>bus route</b> relation ID or URL
+            Enter a <b>bus route</b> relation ID
         </h5>
         <form class="body" id="load-relation-form">
             <input class="form-control mb-2" name="relation-id"

--- a/web/templates/_menu.jinja2
+++ b/web/templates/_menu.jinja2
@@ -4,10 +4,10 @@
 
     <div class="view" id="view-load">
         <h5 class="title">
-            Enter a <b>bus route</b> relation ID
+            Enter a <b>bus route</b> relation ID or URL
         </h5>
         <form class="body" id="load-relation-form">
-            <input type="number" class="form-control mb-2" name="relation-id"
+            <input class="form-control mb-2" name="relation-id"
                 value="{{ request.query_params.get('relation', '') }}" required>
             <button type="submit" class="btn btn-load btn-primary w-100">
                 Load

--- a/web/templates/_menu.jinja2
+++ b/web/templates/_menu.jinja2
@@ -7,7 +7,7 @@
             Enter a <b>bus route</b> relation ID
         </h5>
         <form class="body" id="load-relation-form">
-            <input class="form-control mb-2" name="relation-id"
+            <input type="text" class="form-control mb-2" name="relation-id"
                 value="{{ request.query_params.get('relation', '') }}" required>
             <button type="submit" class="btn btn-load btn-primary w-100">
                 Load


### PR DESCRIPTION
Hi, a common use case I think is getting the relation ID from openstreetmap.org, and the quickest way is to copy the whole URL.

So we could try to parse the URL to get the id. What do you think ?