### PR TITLE
Remove service=driveway2

### DIFF
--- a/web/overpass.py
+++ b/web/overpass.py
@@ -136,7 +136,6 @@ def is_road(tags: dict[str, str]) -> bool:
 
     service_valid = tags.get('service', 'no') not in {
         'driveway',
-        'driveway2',
         'parking_aisle',
         'alley',
         'emergency_access',


### PR DESCRIPTION
It's no longer needed.
See
https://community.openstreetmap.org/t/proposed-bulk-removal-of-service-driveway2/100549/57
https://taginfo.openstreetmap.org/tags/service=driveway2
https://taghistory.raifer.tech/?#***/service/driveway2
