### PR TITLE
Update backend packages link

### DIFF
--- a/web/templates/_licenses_modal.jinja2
+++ b/web/templates/_licenses_modal.jinja2
@@ -86,7 +86,7 @@
 
                         <tr>
                             <td class="text-center" colspan="2">
-                                <pre>🐍 <a href="https://github.com/Zaczero/osm-relatify/blob/main/web/Pipfile" target="_blank">See backend packages</a></pre>
+                                <pre>🐍 <a href="https://github.com/Zaczero/osm-relatify/blob/main/web/pyproject.toml" target="_blank">See backend packages</a></pre>
                             </td>
                         </tr>
 


### PR DESCRIPTION
Since https://github.com/Zaczero/osm-relatify/commit/dc1dcf5861a6c4b2d42bdbf9390eb577a67e4334 there isn't a Pipfile in the repository.