### PR TITLE
Add explainer message about hidden "finish editing" button

### DIFF
--- a/static/js/menu.js
+++ b/static/js/menu.js
@@ -17,6 +17,7 @@ const editBackBtn = document.querySelector("#view-edit .btn-back")
 const editReloadBtn = document.querySelector("#view-edit .btn-reload")
 const editTags = document.getElementById("edit-tags")
 const editWarnings = document.getElementById("edit-warnings")
+const editFixToSubmit = document.getElementById("fix-to-continue")
 const editSubmitBtn = document.querySelector("#view-edit .btn-next")
 const sumitBackBtn = document.querySelector("#view-submit .btn-back")
 const routeSummary = document.getElementById("route-summary")
@@ -130,6 +131,7 @@ export const processRouteWarnings = (data) => {
     if (activeView === "submit") switchView("edit")
 
     editSubmitBtn.classList.add("d-none")
+    editFixToSubmit.classList.add("d-none")
 
     editWarnings.innerHTML = ""
     let highestSeverityLevel = 0
@@ -201,7 +203,10 @@ export const processRouteWarnings = (data) => {
 
     editSubmitBtn.classList.toggle("mt-2", data.warnings.length > 0)
 
-    if (highestSeverityLevel === 0) editSubmitBtn.classList.remove("d-none")
+    if (highestSeverityLevel === 0) {
+        editSubmitBtn.classList.remove("d-none")
+        editFixToSubmit.classList.add("d-none")
+    }
 }
 
 const unload = () => {

--- a/templates/_menu.jinja2
+++ b/templates/_menu.jinja2
@@ -36,6 +36,10 @@
             <div class="actions text-end">
                 <button class="btn btn-primary btn-next w-100 d-none">Finish editing</button>
             </div>
+
+            <i id="fix-to-continue" class="d-none">
+                Fix the errors above to upload
+            </i>
         </div>
     </div>
 


### PR DESCRIPTION
I don't have a development environment set up for Relatify, so ***this change is not tested yet***.

The goal is to add a little message to the bottom of the list of validator warnings/errors when errors exist and the "Finish Editing" button is hidden. I think it's a little confusing as a new user to have no indication of how to save/upload one's edits, so adding this could address issues like #107 (if user confusion is indeed the cause of that issue).