### PR TITLE
Simplify bus stop requirements

### DIFF
--- a/overpass.py
+++ b/overpass.py
@@ -66,13 +66,13 @@ def build_query(
             'out tags qt;'
             'out count;'
             + ''.join(
-                f'node[highway=bus_stop][public_transport=platform][name]({bb});'
+                f'node[public_transport=platform][name]({bb});'
                 f'out tags center qt;'
-                f'nwr[highway=platform][public_transport=platform][name]({bb});'
-                f'out tags center qt;'
-                f'nwr[highway=platform][public_transport=platform][ref]({bb});'
+                f'nwr[public_transport=platform][ref]({bb});'
                 f'out tags center qt;'
                 f'node[public_transport=stop_position][name]({bb});'
+                f'out tags center qt;'
+                f'node[public_transport=stop_position][ref]({bb});'
                 f'out tags center qt;'
                 for bb in cell_bbs_expanded
             )


### PR DESCRIPTION
Look for `public_transport=platform` + (`name` or `ref`) and `public_transport=stop_position` + (`name` or `ref`) and drop `highway=bus_stop` and `highway=platform` requirements

Resolves #65 